### PR TITLE
[HOTFIX] Fix bug that didn't reset the days radioGroup selection on s…

### DIFF
--- a/src/components/CreateGroupForm/CreateGroupForm.tsx
+++ b/src/components/CreateGroupForm/CreateGroupForm.tsx
@@ -100,7 +100,7 @@ export default function CreateGroupForm() {
 
   const [inputValues, dispatchInputValues] = useReducer(
     inputValuesReducer,
-    INPUT_VALUES_INITIAL
+    JSON.parse(JSON.stringify(INPUT_VALUES_INITIAL))
   );
 
   const [inputErrors, dispatchError] = useReducer(
@@ -124,7 +124,7 @@ export default function CreateGroupForm() {
     setFilteredSubjects(subjects);
     dispatchInputValues({
       type: 'UPDATE_VALUES',
-      payload: INPUT_VALUES_INITIAL,
+      payload: JSON.parse(JSON.stringify(INPUT_VALUES_INITIAL)),
     });
     dispatchError({ type: 'UPDATE_ERRORS', payload: INPUT_ERRORES_INITIAL });
   };


### PR DESCRIPTION
@CarLosVegga found a bug in the Create Group Form. 

After submitting a form request, if you open the modal again, the previous days selected would remain active on the modal. After a thorough examination , the bug was caused by the how useReducer works. 
The initial state is being passed with shallow copy. So, our initial days array is being modified on every dispatch call. The solution is to  wrap the useReducer initial state with JSON.parse(JSON.stringify(INPUT_VALUES_INITIAL)), to force a deep copy.

https://github.com/Code4UHub/client/assets/85084188/18e2a68d-f709-4eb5-ab5e-bcf9ed5b5ab1

